### PR TITLE
Adding a parser for .edgerc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ Basic use of the library looks like the following. This will prepare the auth he
 
 ```
 
+In addition passing the credentials manually as above, you may also authenticate using a `.edgerc` file, specifying its path and the group name (default is 'default'):
+
+```javascript
+var eg = new EdgeGrid({
+  path: '/path/to/.edgerc',
+  group: 'mygroup'
+});
+```
+
+An `.edgerc` file contains groups of credentials and is usually hosted in your home directory:
+
+```plaintext
+[default]
+host = akaa-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.luna.akamaiapis.net/
+client_token = akab-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX
+client_secret = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+access_token = akab-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX
+max-body = 131072
+
+[mygroup]
+host = akaa-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.luna.akamaiapis.net/
+client_token = akab-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX
+client_secret = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+access_token = akab-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX
+max-body = 131072
+```
+
 Calls using the edgegrid client can also be chained as per the following;
 
 ```javascript

--- a/src/api.js
+++ b/src/api.js
@@ -2,6 +2,7 @@
 
 var https = require('https'),
   url = require('url');
+  fs = require('fs');
 // EdgeGrid Auth Module
 var auth = require('./auth.js');
 
@@ -11,26 +12,79 @@ var _client_token = null,
   _base_uri = null,
   _request = null;
 
-var EdgeGrid = function(client_token, client_secret, access_token, base_uri) {
-
-  if (client_token === undefined || client_token === null) {
-    console.log("No client token");
-    return false;
-  } else if (client_secret === undefined || client_secret === null) {
-    console.log("No client secret");
-    return false;
-  } else if (access_token === undefined || access_token === null) {
-    console.log("No access token");
-    return false;
-  } else if (base_uri === undefined || base_uri === null) {
-    console.log("No base uri");
-    return false;
+function parseEdgerc(path, conf) {
+  var edgerc = fs.readFileSync(path).toString().split("\n");
+  var confData = [];
+  for(var i=0;i<edgerc.length;i++) {
+    var matchConf = edgerc[i].match(/\[(.*)\]/);
+    // if we found our matching config, push the next 4 lines into a temp array
+    if (matchConf && matchConf[1] === conf) {
+      confData.push(edgerc[i+1]);
+      confData.push(edgerc[i+2]);
+      confData.push(edgerc[i+3]);
+      confData.push(edgerc[i+4]);
+      // convert the array to a descriptive object
+      confData = confData.map(function(el) {
+        var ret = {}
+        var key = el.split(' = ')[0].trim();
+        var val = el.split(' = ')[1].trim();
+        if (key === 'host') {
+          val = 'https://' + val;
+        }
+        ret[key] = val;
+        return ret;
+      });
+      // turn the array of objects into a single object
+      var result = {};
+      for (var i = 0, length = confData.length; i < length; i++) {
+        result[Object.keys(confData[i])[0]] = confData[i][Object.keys(confData[i])[0]];
+      }
+      return result;
+    }
   }
+  // if we escaped the parse loop without returning, something is wrong
+  throw('An error occurred parsing the .edgerc file. You probably specified an invalid group name.');
+} 
 
-  _client_token = client_token;
-  _client_secret = client_secret;
-  _access_token = access_token;
-  _base_uri = base_uri;
+var EdgeGrid = function(client_token, client_secret, access_token, base_uri) {
+  // accepting an object containing a path to .edgerc and a config group
+  if (typeof arguments[0] === 'object') {
+    var path = arguments[0].path;
+    var group = arguments[0].group;
+    if (path === undefined) {
+      console.log("No .edgerc path");
+      return false;
+    }
+    if (group === undefined) {
+      console.log("No .edgerc group provided, using 'default'");
+      group = 'default';
+    }
+    var config = parseEdgerc(path, group);
+    _client_token = config.client_token;
+    _client_secret = config.client_secret;
+    _access_token = config.access_token;
+    _base_uri = config.host;
+  }
+  else {
+    if (client_token === undefined || client_token === null) {
+      console.log("No client token");
+      return false;
+    } else if (client_secret === undefined || client_secret === null) {
+      console.log("No client secret");
+      return false;
+    } else if (access_token === undefined || access_token === null) {
+      console.log("No access token");
+      return false;
+    } else if (base_uri === undefined || base_uri === null) {
+      console.log("No base uri");
+      return false;
+    }
+
+    _client_token = client_token;
+    _client_secret = client_secret;
+    _access_token = access_token;
+    _base_uri = base_uri;
+  }
 
   return this;
 


### PR DESCRIPTION
Most EdgeGrid authenticators parse `.edgerc` configuration files. This PR adds that functionality to this module.

Inside `api.js` I've added a `parseEdgerc()` function that handles the actual file parsing. I changed the API so that in addition to accepting four credentials as arguments, it also accepts an object with a `path` string pointing to an `.edgerc` file (or any file really, but .edgerc by convention), and a `group` that can be specified (since `.edgerc` files can contain multiple named groups of credentials).

I updated the Readme but didn't see an easy avenue for adding tests (since we're just testing the auth and not the API itself). Let me know if you think tests are necessary too.