### PR TITLE
Support multiple content-type headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edgegrid",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Authorisation process and API helper for Akamai OPEN APIs",
   "main": "index.js",
   "scripts": {

--- a/src/api.js
+++ b/src/api.js
@@ -110,8 +110,22 @@ EdgeGrid.prototype.send = function(callback) {
   request.port = parts.port;
   request.path = parts.path;
 
+  // headers are case-insensitive so this function returns the value of a header
+  // no matter what its case is. Returns undefined if there's no header defined.
+  request.getHeader = function(header) {
+    var result = undefined;
+    for (k in this.headers) {
+      if (k.toLowerCase() === header) {
+        result = this.headers[k];
+        break;
+      }
+    }
+    return result;
+  }
+
   if (request.method == "POST" || request.method == "PUT") {
-    request.headers["content-type"] = 'application/x-www-form-urlencoded';
+    // Accept user-defined, case-insensitive content-type header -- or use default type
+    request.headers['content-type'] = request.getHeader('content-type') || 'application/x-www-form-urlencoded';
     request.headers['content-length'] = request.body.length;
   }
 


### PR DESCRIPTION
I was recently using the [Media Streaming API](https://developer.akamai.com/api/luna/config-media-live/overview.html) and it requires a `content-type: application/xml` in its headers. As currently written, the library ignores any `content-type` headers sent to it, in favor of assuming that all PUT/POST requests use a `content-type: application/x-www-form-urlencoded` header.

This PR adds support for user-defined content-type headers, defaulting to `application/x-www-form-urlencoded` if a POST or PUT doesn't define the header. I also had to add a helper function to check for values on case-insensitive object keys, since HTTP headers are case-insensitive.

I've also bumped the npm version so if you accept this, please go ahead and `npm publish`. Thanks!